### PR TITLE
Update Deauth::select() method

### DIFF
--- a/minigotchi/deauth.cpp
+++ b/minigotchi/deauth.cpp
@@ -302,7 +302,7 @@ bool Deauth::select() {
 
 void Deauth::deauth() {
     if (Config::deauth) {
-       // select AP{
+       // select AP
         if (Deauth::select()) {
             if (randomAP.length() > 0) {
                 Serial.println("(>-<) Starting deauthentication attack on the selected AP...");

--- a/minigotchi/deauth.h
+++ b/minigotchi/deauth.h
@@ -31,7 +31,7 @@ private:
     static String printHidden(int network);
     static void printMac(uint8_t* mac);
     static String printMacStr(uint8_t* mac);
-    static void select();
+    static bool select();
     static void start();
     static uint8_t bssid[6];
     static bool running;


### PR DESCRIPTION
I realized too late from my last issue that there was one other aspect that should be updated / reviewed

Currently the Deauth::select() method sets the class-level variable for randomAP if it finds an AP, but it may not want to use that AP (whitelist, no encryption, etc). Since it sets it regardless though, even if we want to ignore that AP, it will still currently deauth it because Deauth::deauth() just checks that one is set.

I had updated mine locally so that select() returns a bool indicating if it actually found one it wants to use, and the deauth() method is driven off that bool.

An alternative is to just not set the class-level variable until we do all the initial checks on the selected AP, but the deauth() method currently considers it as something going wrong if select() was called but no randomAP value was set. So I opted to go for the bool implementation to make driving it more streamlined. 